### PR TITLE
feat: add fair multiplayer piece mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/lib/game/game_logic.dart
+++ b/lib/game/game_logic.dart
@@ -8,6 +8,8 @@ import '../constants/game_constants.dart';
 import '../models/tetromino.dart';
 
 class GameLogic extends ChangeNotifier {
+  /// Source of upcoming tetrominoes for this game.
+  final TetrominoBag pieceBag;
   AudioService? audioService;
 
   /// Called after lines are cleared (multiplayer: send garbage to opponent).
@@ -60,7 +62,7 @@ class GameLogic extends ChangeNotifier {
   bool isAnimatingTrail = false;
   Timer? trailAnimationTimer;
 
-  GameLogic() {
+  GameLogic({TetrominoBag? pieceBag}) : pieceBag = pieceBag ?? TetrominoBag() {
     initializeBoard();
   }
 
@@ -109,7 +111,7 @@ class GameLogic extends ChangeNotifier {
     _lastMoveWasRotation = false;
     _pendingTSpin = false;
 
-    Tetromino.resetBag();
+    pieceBag.reset();
     initializeBoard();
     spawnNewPiece();
     startGameTimer();
@@ -166,10 +168,10 @@ class GameLogic extends ChangeNotifier {
   }
 
   void spawnNewPiece() {
-    nextPiece ??= Tetromino.random();
+    nextPiece ??= pieceBag.next();
 
     currentPiece = nextPiece;
-    nextPiece = Tetromino.random();
+    nextPiece = pieceBag.next();
     currentX = GameConstants.boardWidth ~/ 2 - 1;
     currentY = GameConstants.previewRows;
 

--- a/lib/models/tetromino.dart
+++ b/lib/models/tetromino.dart
@@ -66,24 +66,14 @@ class Tetromino {
     ),
   ];
 
-  // 7-bag algorithm implementation
-  static List<Tetromino> _bag = [];
-  static final Random _random = Random();
+  static final TetrominoBag _defaultBag = TetrominoBag();
 
   static Tetromino random() {
-    // If bag is empty, refill it with a shuffled set of all 7 pieces
-    if (_bag.isEmpty) {
-      _bag = List.from(pieces);
-      _bag.shuffle(_random);
-    }
-
-    // Take the next piece from the bag
-    return _bag.removeLast();
+    return _defaultBag.next();
   }
 
-  // Optional: Reset the bag (useful when starting a new game)
   static void resetBag() {
-    _bag.clear();
+    _defaultBag.reset();
   }
 
   Tetromino rotate() {
@@ -105,5 +95,39 @@ class Tetromino {
           List.generate(shape.length, (j) => shape[j][shape[0].length - 1 - i]),
     );
     return Tetromino(shape: rotated, color: color);
+  }
+}
+
+/// Produces tetrominoes using the standard 7-bag shuffle.
+class TetrominoBag {
+  final int? _seed;
+  final List<Tetromino> _bag = [];
+  late Random _random;
+
+  /// Creates a random bag, or a deterministic bag when [seed] is provided.
+  TetrominoBag({int? seed}) : _seed = seed {
+    _random = _createRandom();
+  }
+
+  Random _createRandom() {
+    return _seed == null ? Random() : Random(_seed);
+  }
+
+  /// Returns the next piece, refilling and shuffling the bag when needed.
+  Tetromino next() {
+    if (_bag.isEmpty) {
+      _bag.addAll(Tetromino.pieces);
+      _bag.shuffle(_random);
+    }
+
+    return _bag.removeLast();
+  }
+
+  /// Clears pending pieces and restarts deterministic bags from their seed.
+  void reset() {
+    _bag.clear();
+    if (_seed != null) {
+      _random = _createRandom();
+    }
   }
 }

--- a/lib/multiplayer/multiplayer_game_config.dart
+++ b/lib/multiplayer/multiplayer_game_config.dart
@@ -1,0 +1,88 @@
+import '../models/tetromino.dart';
+
+/// Controls how multiplayer piece sequences are generated.
+enum MultiplayerGameMode {
+  independent,
+  sharedPieces,
+}
+
+/// Wire-format helpers and lobby labels for [MultiplayerGameMode].
+extension MultiplayerGameModeInfo on MultiplayerGameMode {
+  /// Stable value sent over the multiplayer socket.
+  String get wireName {
+    return switch (this) {
+      MultiplayerGameMode.independent => 'independent',
+      MultiplayerGameMode.sharedPieces => 'shared_pieces',
+    };
+  }
+
+  /// Short label used in the lobby mode selector.
+  String get label {
+    return switch (this) {
+      MultiplayerGameMode.independent => 'Random',
+      MultiplayerGameMode.sharedPieces => 'Fair',
+    };
+  }
+
+  /// Parses a socket value, defaulting to the legacy independent mode.
+  static MultiplayerGameMode fromWireName(Object? value) {
+    return switch (value) {
+      'shared_pieces' => MultiplayerGameMode.sharedPieces,
+      _ => MultiplayerGameMode.independent,
+    };
+  }
+}
+
+/// Game-start settings shared by both players before a match begins.
+class MultiplayerGameConfig {
+  /// Piece sequence policy for this match.
+  final MultiplayerGameMode mode;
+
+  /// Seed used when [mode] is [MultiplayerGameMode.sharedPieces].
+  final int? pieceSeed;
+
+  const MultiplayerGameConfig._({required this.mode, this.pieceSeed});
+
+  /// Creates a config where each player uses their own random 7-bag.
+  const MultiplayerGameConfig.independent()
+      : this._(mode: MultiplayerGameMode.independent);
+
+  /// Creates a config where both players use the same seeded 7-bag.
+  const MultiplayerGameConfig.sharedPieces({required int pieceSeed})
+      : this._(
+          mode: MultiplayerGameMode.sharedPieces,
+          pieceSeed: pieceSeed,
+        );
+
+  /// Decodes a `game_start` socket payload.
+  factory MultiplayerGameConfig.fromGameStartMessage(
+    Map<String, dynamic> message,
+  ) {
+    final mode = MultiplayerGameModeInfo.fromWireName(message['mode']);
+    final seed = (message['piece_seed'] as num?)?.toInt();
+
+    if (mode == MultiplayerGameMode.sharedPieces && seed != null) {
+      return MultiplayerGameConfig.sharedPieces(pieceSeed: seed);
+    }
+
+    return const MultiplayerGameConfig.independent();
+  }
+
+  /// Encodes this config as a `game_start` socket payload.
+  Map<String, dynamic> toGameStartMessage() {
+    return {
+      'type': 'game_start',
+      'mode': mode.wireName,
+      if (pieceSeed != null) 'piece_seed': pieceSeed,
+    };
+  }
+
+  /// Creates the piece bag a local game should use for this config.
+  TetrominoBag createPieceBag() {
+    if (mode == MultiplayerGameMode.sharedPieces && pieceSeed != null) {
+      return TetrominoBag(seed: pieceSeed);
+    }
+
+    return TetrominoBag();
+  }
+}

--- a/lib/multiplayer/multiplayer_manager.dart
+++ b/lib/multiplayer/multiplayer_manager.dart
@@ -5,6 +5,7 @@ import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 
+import 'multiplayer_game_config.dart';
 import 'peer.dart';
 
 enum MultiplayerState {
@@ -20,6 +21,7 @@ enum MultiplayerState {
 class MultiplayerManager extends ChangeNotifier {
   static const int _udpPort = 45678;
   static const int _tcpPort = 45679;
+  static const int _maxPieceSeed = 0x7fffffff;
 
   final String playerId;
   final String playerName;
@@ -30,6 +32,22 @@ class MultiplayerManager extends ChangeNotifier {
   bool get isHost => _isHost;
   int _localPort = _tcpPort;
   String? _broadcastAddress;
+
+  /// Piece sequence mode selected for the next multiplayer match.
+  MultiplayerGameMode gameMode = MultiplayerGameMode.independent;
+
+  /// Seed shared by both players when [gameMode] is shared pieces.
+  int? sharedPieceSeed;
+
+  /// Match configuration the game screen should use when play begins.
+  MultiplayerGameConfig get gameConfig {
+    if (gameMode == MultiplayerGameMode.sharedPieces &&
+        sharedPieceSeed != null) {
+      return MultiplayerGameConfig.sharedPieces(pieceSeed: sharedPieceSeed!);
+    }
+
+    return const MultiplayerGameConfig.independent();
+  }
 
   // Opponent state (updated via board_snapshot messages)
   List<int> opponentBoard = List.filled(200, 0); // 20 rows × 10 cols
@@ -65,6 +83,10 @@ class MultiplayerManager extends ChangeNotifier {
       8,
       (_) => r.nextInt(256).toRadixString(16).padLeft(2, '0'),
     ).join();
+  }
+
+  static int _generatePieceSeed() {
+    return Random.secure().nextInt(_maxPieceSeed);
   }
 
   // ── Discovery ────────────────────────────────────────────────────────────
@@ -265,6 +287,7 @@ class MultiplayerManager extends ChangeNotifier {
     state = MultiplayerState.inviting;
     opponentName = peer.name;
     _isHost = true;
+    _resetGameConfig();
     notifyListeners();
 
     try {
@@ -300,11 +323,13 @@ class MultiplayerManager extends ChangeNotifier {
     state = MultiplayerState.discovering;
     opponentName = null;
     _isHost = false;
+    _resetGameConfig();
     notifyListeners();
   }
 
   void acceptInvite() {
     if (state != MultiplayerState.invited) return;
+    _resetGameConfig();
     _send({'type': 'invite_accept', 'name': playerName});
     state = MultiplayerState.inLobby;
     notifyListeners();
@@ -316,6 +341,7 @@ class MultiplayerManager extends ChangeNotifier {
     _closeConnection();
     state = MultiplayerState.discovering;
     opponentName = null;
+    _resetGameConfig();
     notifyListeners();
   }
 
@@ -324,9 +350,31 @@ class MultiplayerManager extends ChangeNotifier {
   /// Host only – sends game_start to guest then changes own state.
   void startGame() {
     if (state != MultiplayerState.inLobby || !_isHost) return;
-    _send({'type': 'game_start'});
+    final config = _createGameStartConfig();
+    _send(config.toGameStartMessage());
     state = MultiplayerState.inGame;
     notifyListeners();
+  }
+
+  /// Host only – selects the piece sequence mode shown in the lobby.
+  void setGameMode(MultiplayerGameMode mode) {
+    if (state != MultiplayerState.inLobby || !_isHost) return;
+    if (gameMode == mode) return;
+
+    gameMode = mode;
+    sharedPieceSeed = null;
+    _send({'type': 'game_mode', 'mode': mode.wireName});
+    notifyListeners();
+  }
+
+  MultiplayerGameConfig _createGameStartConfig() {
+    if (gameMode == MultiplayerGameMode.sharedPieces) {
+      sharedPieceSeed = _generatePieceSeed();
+      return MultiplayerGameConfig.sharedPieces(pieceSeed: sharedPieceSeed!);
+    }
+
+    sharedPieceSeed = null;
+    return const MultiplayerGameConfig.independent();
   }
 
   void sendGarbage(int lines) {
@@ -362,6 +410,7 @@ class MultiplayerManager extends ChangeNotifier {
     opponentScore = 0;
     opponentLines = 0;
     _isHost = false;
+    _resetGameConfig();
     notifyListeners();
   }
 
@@ -421,12 +470,23 @@ class MultiplayerManager extends ChangeNotifier {
             state = MultiplayerState.discovering;
             opponentName = null;
             _isHost = false;
+            _resetGameConfig();
             notifyListeners();
             onError?.call('Invite was declined');
           }
 
+        case 'game_mode':
+          if (state == MultiplayerState.inLobby && !_isHost) {
+            gameMode = MultiplayerGameModeInfo.fromWireName(msg['mode']);
+            sharedPieceSeed = null;
+            notifyListeners();
+          }
+
         case 'game_start':
           if (state == MultiplayerState.inLobby) {
+            final config = MultiplayerGameConfig.fromGameStartMessage(msg);
+            gameMode = config.mode;
+            sharedPieceSeed = config.pieceSeed;
             state = MultiplayerState.inGame;
             notifyListeners();
           }
@@ -477,6 +537,7 @@ class MultiplayerManager extends ChangeNotifier {
       opponentName = null;
       opponentIsGameOver = false;
       _isHost = false;
+      _resetGameConfig();
       notifyListeners();
     }
   }
@@ -494,6 +555,11 @@ class MultiplayerManager extends ChangeNotifier {
       _peerSocket?.destroy();
     } catch (_) {}
     _peerSocket = null;
+  }
+
+  void _resetGameConfig() {
+    gameMode = MultiplayerGameMode.independent;
+    sharedPieceSeed = null;
   }
 
   @override

--- a/lib/screens/multiplayer_discovery_screen.dart
+++ b/lib/screens/multiplayer_discovery_screen.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 
+import '../multiplayer/multiplayer_game_config.dart';
 import '../multiplayer/multiplayer_manager.dart';
 import '../multiplayer/peer.dart';
 import '../settings/settings_provider.dart';
@@ -396,6 +397,15 @@ class _MultiplayerDiscoveryScreenState
             colorScheme: cs,
             style: widget.settings.style,
           ),
+          const SizedBox(height: 18),
+          if (_manager.isHost)
+            _LobbyModeSelector(
+              mode: _manager.gameMode,
+              colorScheme: cs,
+              onChanged: _manager.setGameMode,
+            )
+          else
+            _LobbyModeStatus(mode: _manager.gameMode, colorScheme: cs),
           const Spacer(),
           if (_manager.isHost) ...[
             Text(
@@ -433,6 +443,79 @@ class _MultiplayerDiscoveryScreenState
 }
 
 // ── Reusable sub-widgets ──────────────────────────────────────────────────────
+
+IconData _gameModeIcon(MultiplayerGameMode mode) {
+  return switch (mode) {
+    MultiplayerGameMode.independent => Icons.shuffle,
+    MultiplayerGameMode.sharedPieces => Icons.sync,
+  };
+}
+
+class _LobbyModeSelector extends StatelessWidget {
+  final MultiplayerGameMode mode;
+  final ColorScheme colorScheme;
+  final ValueChanged<MultiplayerGameMode> onChanged;
+
+  const _LobbyModeSelector({
+    required this.mode,
+    required this.colorScheme,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          'Mode',
+          style: TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 12),
+        ),
+        const SizedBox(height: 8),
+        SegmentedButton<MultiplayerGameMode>(
+          showSelectedIcon: false,
+          segments: const [
+            ButtonSegment(
+              value: MultiplayerGameMode.independent,
+              icon: Icon(Icons.shuffle),
+              label: Text('Random'),
+            ),
+            ButtonSegment(
+              value: MultiplayerGameMode.sharedPieces,
+              icon: Icon(Icons.sync),
+              label: Text('Fair'),
+            ),
+          ],
+          selected: {mode},
+          onSelectionChanged: (selection) {
+            if (selection.isNotEmpty) onChanged(selection.first);
+          },
+        ),
+      ],
+    );
+  }
+}
+
+class _LobbyModeStatus extends StatelessWidget {
+  final MultiplayerGameMode mode;
+  final ColorScheme colorScheme;
+
+  const _LobbyModeStatus({required this.mode, required this.colorScheme});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(_gameModeIcon(mode), size: 18, color: colorScheme.primary),
+        const SizedBox(width: 8),
+        Text(
+          '${mode.label} mode',
+          style: TextStyle(color: colorScheme.onSurfaceVariant),
+        ),
+      ],
+    );
+  }
+}
 
 class _PeerTile extends StatelessWidget {
   final Peer peer;

--- a/lib/screens/multiplayer_game_screen.dart
+++ b/lib/screens/multiplayer_game_screen.dart
@@ -68,7 +68,8 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen>
       if (widget.settings.musicEnabled) _audioService.startMusic();
     });
 
-    _gameLogic = GameLogic();
+    _gameLogic =
+        GameLogic(pieceBag: widget.manager.gameConfig.createPieceBag());
     _gameLogic.audioService = _audioService;
     _gameLogic.addListener(_onGameStateChanged);
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:intl/intl.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -93,9 +94,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
       body: SafeArea(
         child: ListView(
           padding: const EdgeInsets.only(top: 8, bottom: 48),
-          // Large cacheExtent ensures all children are laid out off-screen so
+          // Large scrollCacheExtent ensures all children are laid out off-screen so
           // Android TV D-pad focus traversal can reach items below the viewport.
-          cacheExtent: 3000,
+          scrollCacheExtent: const ScrollCacheExtent.pixels(3000),
           children: [
             if (widget.onRestart != null || widget.onQuit != null) ...[
               _SectionHeader(label: 'Game', colorScheme: colorScheme),

--- a/test/game_logic_test.dart
+++ b/test/game_logic_test.dart
@@ -1,5 +1,6 @@
 import 'package:block_drop/constants/game_constants.dart';
 import 'package:block_drop/game/game_logic.dart';
+import 'package:block_drop/models/tetromino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -54,6 +55,31 @@ void main() {
       expect(gameLogic.nextPiece, isNotNull);
       expect(gameLogic.heldPiece, null);
       expect(gameLogic.canHold, true);
+    });
+
+    test('should use injected seeded bag for reproducible piece sequence', () {
+      final firstGame = GameLogic(pieceBag: TetrominoBag(seed: 8675309));
+      final secondGame = GameLogic(pieceBag: TetrominoBag(seed: 8675309));
+
+      try {
+        firstGame.startGame();
+        secondGame.startGame();
+
+        final firstSequence = <Color>[];
+        final secondSequence = <Color>[];
+        for (int i = 0; i < 10; i++) {
+          firstSequence.add(firstGame.currentPiece!.color);
+          secondSequence.add(secondGame.currentPiece!.color);
+          firstGame.spawnNewPiece();
+          secondGame.spawnNewPiece();
+        }
+
+        expect(firstSequence, equals(secondSequence));
+        expect(firstGame.nextPiece!.color, equals(secondGame.nextPiece!.color));
+      } finally {
+        firstGame.dispose();
+        secondGame.dispose();
+      }
     });
 
     test('should detect collision correctly', () {

--- a/test/multiplayer_game_config_test.dart
+++ b/test/multiplayer_game_config_test.dart
@@ -1,0 +1,42 @@
+import 'package:block_drop/multiplayer/multiplayer_game_config.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('MultiplayerGameConfig', () {
+    test('encodes shared-pieces game starts with the seed', () {
+      const config = MultiplayerGameConfig.sharedPieces(pieceSeed: 123456);
+
+      expect(config.toGameStartMessage(), {
+        'type': 'game_start',
+        'mode': 'shared_pieces',
+        'piece_seed': 123456,
+      });
+    });
+
+    test('decodes shared-pieces game starts into deterministic piece bags', () {
+      final config = MultiplayerGameConfig.fromGameStartMessage({
+        'type': 'game_start',
+        'mode': 'shared_pieces',
+        'piece_seed': 2026,
+      });
+
+      final firstBag = config.createPieceBag();
+      final secondBag = config.createPieceBag();
+      final firstSequence = List.generate(14, (_) => firstBag.next().color);
+      final secondSequence = List.generate(14, (_) => secondBag.next().color);
+
+      expect(config.mode, MultiplayerGameMode.sharedPieces);
+      expect(config.pieceSeed, 2026);
+      expect(firstSequence, equals(secondSequence));
+    });
+
+    test('decodes legacy game starts as independent pieces', () {
+      final config = MultiplayerGameConfig.fromGameStartMessage({
+        'type': 'game_start',
+      });
+
+      expect(config.mode, MultiplayerGameMode.independent);
+      expect(config.pieceSeed, isNull);
+    });
+  });
+}

--- a/test/tetromino_test.dart
+++ b/test/tetromino_test.dart
@@ -347,5 +347,25 @@ void main() {
             'Each refilled bag must also contain exactly one of each piece type',
       );
     });
+
+    test('seeded 7-bags yield the same piece sequence', () {
+      final firstBag = TetrominoBag(seed: 20260627);
+      final secondBag = TetrominoBag(seed: 20260627);
+
+      final firstSequence = List.generate(21, (_) => firstBag.next().color);
+      final secondSequence = List.generate(21, (_) => secondBag.next().color);
+
+      expect(firstSequence, equals(secondSequence));
+    });
+
+    test('reset restarts a seeded 7-bag from the same sequence', () {
+      final bag = TetrominoBag(seed: 42);
+
+      final firstRun = List.generate(14, (_) => bag.next().color);
+      bag.reset();
+      final secondRun = List.generate(14, (_) => bag.next().color);
+
+      expect(secondRun, equals(firstRun));
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Adds a fair multiplayer mode where both players receive the same seeded 7-bag piece sequence.
- Keeps the existing random-piece multiplayer mode available.
- Sends the selected multiplayer game config from the host lobby into the game start flow.

## Tests
- Added coverage for deterministic bag generation, injected game logic, and multiplayer game-start config.
- Verified with `flutter analyze` and `flutter test`.

## Authorship note
This change was written by an AI assistant, not by me personally. I do not really know Dart or Flutter, so this is AI-slop, but it appears to work.