### PR TITLE
feat: add hold piece setting

### DIFF
--- a/lib/game/game_logic.dart
+++ b/lib/game/game_logic.dart
@@ -11,6 +11,7 @@ class GameLogic extends ChangeNotifier {
   /// Source of upcoming tetrominoes for this game.
   final TetrominoBag pieceBag;
   AudioService? audioService;
+  bool enableHold;
 
   /// Called after lines are cleared (multiplayer: send garbage to opponent).
   /// Set by the multiplayer game screen; null in solo play (zero overhead).
@@ -62,7 +63,9 @@ class GameLogic extends ChangeNotifier {
   bool isAnimatingTrail = false;
   Timer? trailAnimationTimer;
 
-  GameLogic({TetrominoBag? pieceBag}) : pieceBag = pieceBag ?? TetrominoBag() {
+  GameLogic({TetrominoBag? pieceBag, bool? enableHold})
+      : pieceBag = pieceBag ?? TetrominoBag(),
+        enableHold = enableHold ?? true {
     initializeBoard();
   }
 
@@ -625,7 +628,7 @@ class GameLogic extends ChangeNotifier {
   }
 
   void holdPiece() {
-    if (!canHold || currentPiece == null) return;
+    if (!enableHold || !canHold || currentPiece == null) return;
 
     audioService?.playHold();
 

--- a/lib/multiplayer/multiplayer_game_config.dart
+++ b/lib/multiplayer/multiplayer_game_config.dart
@@ -41,17 +41,27 @@ class MultiplayerGameConfig {
   /// Seed used when [mode] is [MultiplayerGameMode.sharedPieces].
   final int? pieceSeed;
 
-  const MultiplayerGameConfig._({required this.mode, this.pieceSeed});
+  /// Whether the hold mechanic is enabled for this match.
+  final bool enableHold;
+
+  const MultiplayerGameConfig._({
+    required this.mode,
+    this.pieceSeed,
+    this.enableHold = true,
+  });
 
   /// Creates a config where each player uses their own random 7-bag.
-  const MultiplayerGameConfig.independent()
-      : this._(mode: MultiplayerGameMode.independent);
+  const MultiplayerGameConfig.independent({bool enableHold = true})
+      : this._(mode: MultiplayerGameMode.independent, enableHold: enableHold);
 
   /// Creates a config where both players use the same seeded 7-bag.
-  const MultiplayerGameConfig.sharedPieces({required int pieceSeed})
-      : this._(
+  const MultiplayerGameConfig.sharedPieces({
+    required int pieceSeed,
+    bool enableHold = true,
+  }) : this._(
           mode: MultiplayerGameMode.sharedPieces,
           pieceSeed: pieceSeed,
+          enableHold: enableHold,
         );
 
   /// Decodes a `game_start` socket payload.
@@ -60,12 +70,16 @@ class MultiplayerGameConfig {
   ) {
     final mode = MultiplayerGameModeInfo.fromWireName(message['mode']);
     final seed = (message['piece_seed'] as num?)?.toInt();
+    final enableHold = message['enable_hold'] as bool? ?? true;
 
     if (mode == MultiplayerGameMode.sharedPieces && seed != null) {
-      return MultiplayerGameConfig.sharedPieces(pieceSeed: seed);
+      return MultiplayerGameConfig.sharedPieces(
+        pieceSeed: seed,
+        enableHold: enableHold,
+      );
     }
 
-    return const MultiplayerGameConfig.independent();
+    return MultiplayerGameConfig.independent(enableHold: enableHold);
   }
 
   /// Encodes this config as a `game_start` socket payload.
@@ -74,6 +88,7 @@ class MultiplayerGameConfig {
       'type': 'game_start',
       'mode': mode.wireName,
       if (pieceSeed != null) 'piece_seed': pieceSeed,
+      'enable_hold': enableHold,
     };
   }
 

--- a/lib/multiplayer/multiplayer_manager.dart
+++ b/lib/multiplayer/multiplayer_manager.dart
@@ -36,6 +36,9 @@ class MultiplayerManager extends ChangeNotifier {
   /// Piece sequence mode selected for the next multiplayer match.
   MultiplayerGameMode gameMode = MultiplayerGameMode.independent;
 
+  /// Whether hold is enabled for the next multiplayer match.
+  bool enableHold = true;
+
   /// Seed shared by both players when [gameMode] is shared pieces.
   int? sharedPieceSeed;
 
@@ -43,10 +46,13 @@ class MultiplayerManager extends ChangeNotifier {
   MultiplayerGameConfig get gameConfig {
     if (gameMode == MultiplayerGameMode.sharedPieces &&
         sharedPieceSeed != null) {
-      return MultiplayerGameConfig.sharedPieces(pieceSeed: sharedPieceSeed!);
+      return MultiplayerGameConfig.sharedPieces(
+        pieceSeed: sharedPieceSeed!,
+        enableHold: enableHold,
+      );
     }
 
-    return const MultiplayerGameConfig.independent();
+    return MultiplayerGameConfig.independent(enableHold: enableHold);
   }
 
   // Opponent state (updated via board_snapshot messages)
@@ -370,11 +376,14 @@ class MultiplayerManager extends ChangeNotifier {
   MultiplayerGameConfig _createGameStartConfig() {
     if (gameMode == MultiplayerGameMode.sharedPieces) {
       sharedPieceSeed = _generatePieceSeed();
-      return MultiplayerGameConfig.sharedPieces(pieceSeed: sharedPieceSeed!);
+      return MultiplayerGameConfig.sharedPieces(
+        pieceSeed: sharedPieceSeed!,
+        enableHold: enableHold,
+      );
     }
 
     sharedPieceSeed = null;
-    return const MultiplayerGameConfig.independent();
+    return MultiplayerGameConfig.independent(enableHold: enableHold);
   }
 
   void sendGarbage(int lines) {
@@ -487,6 +496,7 @@ class MultiplayerManager extends ChangeNotifier {
             final config = MultiplayerGameConfig.fromGameStartMessage(msg);
             gameMode = config.mode;
             sharedPieceSeed = config.pieceSeed;
+            enableHold = config.enableHold;
             state = MultiplayerState.inGame;
             notifyListeners();
           }
@@ -560,6 +570,7 @@ class MultiplayerManager extends ChangeNotifier {
   void _resetGameConfig() {
     gameMode = MultiplayerGameMode.independent;
     sharedPieceSeed = null;
+    enableHold = true;
   }
 
   @override

--- a/lib/screens/multiplayer_discovery_screen.dart
+++ b/lib/screens/multiplayer_discovery_screen.dart
@@ -398,13 +398,20 @@ class _MultiplayerDiscoveryScreenState
             style: widget.settings.style,
           ),
           const SizedBox(height: 18),
-          if (_manager.isHost)
+          if (_manager.isHost) ...[
             _LobbyModeSelector(
               mode: _manager.gameMode,
               colorScheme: cs,
               onChanged: _manager.setGameMode,
-            )
-          else
+            ),
+            const SizedBox(height: 16),
+            _LobbyHoldSelector(
+              enabled: _manager.enableHold,
+              colorScheme: cs,
+              style: widget.settings.style,
+              onChanged: (value) => setState(() => _manager.enableHold = value),
+            ),
+          ] else
             _LobbyModeStatus(mode: _manager.gameMode, colorScheme: cs),
           const Spacer(),
           if (_manager.isHost) ...[
@@ -511,6 +518,41 @@ class _LobbyModeStatus extends StatelessWidget {
         Text(
           '${mode.label} mode',
           style: TextStyle(color: colorScheme.onSurfaceVariant),
+        ),
+      ],
+    );
+  }
+}
+
+class _LobbyHoldSelector extends StatelessWidget {
+  final bool enabled;
+  final ColorScheme colorScheme;
+  final AppStyle style;
+  final ValueChanged<bool> onChanged;
+
+  const _LobbyHoldSelector({
+    required this.enabled,
+    required this.colorScheme,
+    required this.style,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Text(
+          'Hold Piece',
+          style: TextStyle(
+            color: colorScheme.onSurfaceVariant,
+            fontSize: 12,
+          ),
+        ),
+        const SizedBox(width: 12),
+        Switch(
+          value: enabled,
+          onChanged: onChanged,
         ),
       ],
     );

--- a/lib/screens/multiplayer_game_screen.dart
+++ b/lib/screens/multiplayer_game_screen.dart
@@ -68,8 +68,10 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen>
       if (widget.settings.musicEnabled) _audioService.startMusic();
     });
 
-    _gameLogic =
-        GameLogic(pieceBag: widget.manager.gameConfig.createPieceBag());
+    _gameLogic = GameLogic(
+      pieceBag: widget.manager.gameConfig.createPieceBag(),
+      enableHold: widget.manager.gameConfig.enableHold,
+    );
     _gameLogic.audioService = _audioService;
     _gameLogic.addListener(_onGameStateChanged);
 
@@ -341,24 +343,25 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen>
               width: sidebarW,
               child: Column(
                 children: [
-                  _buildSidebarPieceBox(
-                    label: 'HOLD',
-                    size: sidebarW,
-                    cs: cs,
-                    onTap: () {
-                      if (_gameActive &&
-                          _gameLogic.isGameRunning &&
-                          !_gameLogic.isGameOver &&
-                          !_gameLogic.isPaused) {
-                        _gameLogic.holdPiece();
-                      }
-                    },
-                    child: HoldPieceDisplay(
-                      piece: _gameLogic.heldPiece,
-                      style: widget.settings.style,
+                  if (_gameLogic.enableHold)
+                    _buildSidebarPieceBox(
+                      label: 'HOLD',
+                      size: sidebarW,
+                      cs: cs,
+                      onTap: () {
+                        if (_gameActive &&
+                            _gameLogic.isGameRunning &&
+                            !_gameLogic.isGameOver &&
+                            !_gameLogic.isPaused) {
+                          _gameLogic.holdPiece();
+                        }
+                      },
+                      child: HoldPieceDisplay(
+                        piece: _gameLogic.heldPiece,
+                        style: widget.settings.style,
+                      ),
                     ),
-                  ),
-                  const SizedBox(height: 8),
+                  if (_gameLogic.enableHold) const SizedBox(height: 8),
                   _buildSidebarPieceBox(
                     label: 'NEXT',
                     size: sidebarW,
@@ -595,31 +598,34 @@ class _MultiplayerGameScreenState extends State<MultiplayerGameScreen>
           ),
 
           // ── Hold overlay (top-left of board) ──────────────────────
-          Positioned(
-            left: boardLeft + 4,
-            top: boardTop + 4,
-            child: _buildOverlayPieceBox(
-              label: 'HOLD',
-              size: overlayBoxSize,
-              onTap: () {
-                if (_gameActive &&
-                    _gameLogic.isGameRunning &&
-                    !_gameLogic.isGameOver &&
-                    !_gameLogic.isPaused) {
-                  _gameLogic.holdPiece();
-                }
-              },
-              child: HoldPieceDisplay(
-                piece: _gameLogic.heldPiece,
-                style: widget.settings.style,
+          if (_gameLogic.enableHold)
+            Positioned(
+              left: boardLeft + 4,
+              top: boardTop + 4,
+              child: _buildOverlayPieceBox(
+                label: 'HOLD',
+                size: overlayBoxSize,
+                onTap: () {
+                  if (_gameActive &&
+                      _gameLogic.isGameRunning &&
+                      !_gameLogic.isGameOver &&
+                      !_gameLogic.isPaused) {
+                    _gameLogic.holdPiece();
+                  }
+                },
+                child: HoldPieceDisplay(
+                  piece: _gameLogic.heldPiece,
+                  style: widget.settings.style,
+                ),
               ),
             ),
-          ),
 
           // ── Next overlay (below hold) ──────────────────────────────
           Positioned(
             left: boardLeft + 4,
-            top: boardTop + 4 + labelH + overlayBoxSize + 6,
+            top: boardTop +
+                4 +
+                (_gameLogic.enableHold ? labelH + overlayBoxSize + 6 : 0),
             child: _buildOverlayPieceBox(
               label: 'NEXT',
               size: overlayBoxSize,

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -191,6 +191,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 onChanged: (value) => widget.settings.setShowGhostTile(value),
               ),
             ),
+            _SettingTile(
+              label: 'Enable Hold Piece',
+              colorScheme: colorScheme,
+              style: widget.settings.style,
+              child: Switch(
+                value: widget.settings.enableHold,
+                onChanged: (value) => widget.settings.setEnableHold(value),
+              ),
+            ),
             _SectionHeader(label: 'Appearance', colorScheme: colorScheme),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),

--- a/lib/screens/tetris_game_screen.dart
+++ b/lib/screens/tetris_game_screen.dart
@@ -71,7 +71,7 @@ class _TetrisGameScreenState extends State<TetrisGameScreen>
     );
     _audioService.init().then((_) => _audioService.startMusic());
 
-    gameLogic = GameLogic();
+    gameLogic = GameLogic(enableHold: widget.settings.enableHold);
     gameLogic.audioService = _audioService;
     gameLogic.addListener(_onGameStateChanged);
     gameLogic.startGame();
@@ -173,6 +173,7 @@ class _TetrisGameScreenState extends State<TetrisGameScreen>
   void _onSettingsChanged() {
     _audioService.musicEnabled = widget.settings.musicEnabled;
     _audioService.sfxEnabled = widget.settings.sfxEnabled;
+    gameLogic.enableHold = widget.settings.enableHold;
     if (widget.settings.musicEnabled) {
       _audioService.resumeMusic();
     } else {
@@ -569,40 +570,41 @@ class _TetrisGameScreenState extends State<TetrisGameScreen>
                         child: Row(
                           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                           children: [
-                            // Hold piece
-                            GestureDetector(
-                              child: Column(
-                                children: [
-                                  Text(
-                                    'Hold:',
-                                    style: TextStyle(
-                                      color: cs.onSurface,
-                                      fontSize: 16,
+                            if (widget.settings.enableHold)
+                              // Hold piece
+                              GestureDetector(
+                                child: Column(
+                                  children: [
+                                    Text(
+                                      'Hold:',
+                                      style: TextStyle(
+                                        color: cs.onSurface,
+                                        fontSize: 16,
+                                      ),
                                     ),
-                                  ),
-                                  const SizedBox(height: 8),
-                                  Container(
-                                    width: 80,
-                                    height: 80,
-                                    decoration: pieceBoxDecoration(
-                                      widget.settings.style,
-                                      cs,
+                                    const SizedBox(height: 8),
+                                    Container(
+                                      width: 80,
+                                      height: 80,
+                                      decoration: pieceBoxDecoration(
+                                        widget.settings.style,
+                                        cs,
+                                      ),
+                                      child: HoldPieceDisplay(
+                                        piece: gameLogic.heldPiece,
+                                        style: widget.settings.style,
+                                      ),
                                     ),
-                                    child: HoldPieceDisplay(
-                                      piece: gameLogic.heldPiece,
-                                      style: widget.settings.style,
-                                    ),
-                                  ),
-                                ],
+                                  ],
+                                ),
+                                onTap: () {
+                                  if (gameLogic.isGameRunning &&
+                                      !gameLogic.isGameOver &&
+                                      !gameLogic.isPaused) {
+                                    gameLogic.holdPiece();
+                                  }
+                                },
                               ),
-                              onTap: () {
-                                if (gameLogic.isGameRunning &&
-                                    !gameLogic.isGameOver &&
-                                    !gameLogic.isPaused) {
-                                  gameLogic.holdPiece();
-                                }
-                              },
-                            ),
                             // Next piece
                             Column(
                               children: [
@@ -774,31 +776,36 @@ class _TetrisGameScreenState extends State<TetrisGameScreen>
       bh = (boardAvailW / aspect).clamp(100.0, double.infinity);
     }
 
-    Widget holdPanel = GestureDetector(
-      onTap: () {
-        if (gameLogic.isGameRunning &&
-            !gameLogic.isGameOver &&
-            !gameLogic.isPaused) {
-          gameLogic.holdPiece();
-        }
-      },
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text('Hold', style: TextStyle(color: cs.onSurface, fontSize: 18)),
-          const SizedBox(height: 6),
-          Container(
-            width: boxSize,
-            height: boxSize,
-            decoration: pieceBoxDecoration(widget.settings.style, cs),
-            child: HoldPieceDisplay(
-              piece: gameLogic.heldPiece,
-              style: widget.settings.style,
+    Widget holdPanel = widget.settings.enableHold
+        ? GestureDetector(
+            onTap: () {
+              if (gameLogic.isGameRunning &&
+                  !gameLogic.isGameOver &&
+                  !gameLogic.isPaused) {
+                gameLogic.holdPiece();
+              }
+            },
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'Hold',
+                  style: TextStyle(color: cs.onSurface, fontSize: 18),
+                ),
+                const SizedBox(height: 6),
+                Container(
+                  width: boxSize,
+                  height: boxSize,
+                  decoration: pieceBoxDecoration(widget.settings.style, cs),
+                  child: HoldPieceDisplay(
+                    piece: gameLogic.heldPiece,
+                    style: widget.settings.style,
+                  ),
+                ),
+              ],
             ),
-          ),
-        ],
-      ),
-    );
+          )
+        : const SizedBox.shrink();
 
     Widget nextPanel = Column(
       mainAxisSize: MainAxisSize.min,
@@ -955,11 +962,13 @@ class _TetrisGameScreenState extends State<TetrisGameScreen>
             mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              SizedBox(
-                width: sidebarW,
-                child: Center(child: holdPanel),
-              ),
-              SizedBox(width: gap),
+              if (widget.settings.enableHold) ...[
+                SizedBox(
+                  width: sidebarW,
+                  child: Center(child: holdPanel),
+                ),
+                SizedBox(width: gap),
+              ],
               board,
               SizedBox(width: gap),
               SizedBox(

--- a/lib/settings/settings_provider.dart
+++ b/lib/settings/settings_provider.dart
@@ -13,6 +13,7 @@ class SettingsProvider extends ChangeNotifier {
   static const _highScoreKey = 'high_score';
   static const _showGhostTileKey = 'show_ghost_tile';
   static const _showOpponentBoardKey = 'show_opponent_board';
+  static const _enableHoldKey = 'enable_hold';
 
   AppThemeMode _themeMode = AppThemeMode.system;
   AppStyle _style = AppStyle.classic;
@@ -21,6 +22,7 @@ class SettingsProvider extends ChangeNotifier {
   int _highScore = 0;
   bool _showGhostTile = true;
   bool _showOpponentBoard = true;
+  bool _enableHold = true;
 
   AppThemeMode get themeMode => _themeMode;
   AppStyle get style => _style;
@@ -29,6 +31,7 @@ class SettingsProvider extends ChangeNotifier {
   int get highScore => _highScore;
   bool get showGhostTile => _showGhostTile;
   bool get showOpponentBoard => _showOpponentBoard;
+  bool get enableHold => _enableHold;
 
   ThemeMode get flutterThemeMode {
     switch (_themeMode) {
@@ -58,6 +61,7 @@ class SettingsProvider extends ChangeNotifier {
     _highScore = prefs.getInt(_highScoreKey) ?? 0;
     _showGhostTile = prefs.getBool(_showGhostTileKey) ?? true;
     _showOpponentBoard = prefs.getBool(_showOpponentBoardKey) ?? true;
+    _enableHold = prefs.getBool(_enableHoldKey) ?? true;
     notifyListeners();
   }
 
@@ -101,6 +105,13 @@ class SettingsProvider extends ChangeNotifier {
     notifyListeners();
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_showOpponentBoardKey, value);
+  }
+
+  Future<void> setEnableHold(bool value) async {
+    _enableHold = value;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_enableHoldKey, value);
   }
 
   Future<void> updateHighScore(int score) async {

--- a/test/game_logic_test.dart
+++ b/test/game_logic_test.dart
@@ -26,6 +26,7 @@ void main() {
       expect(gameLogic.nextPiece, null);
       expect(gameLogic.heldPiece, null);
       expect(gameLogic.canHold, true);
+      expect(gameLogic.enableHold, true);
     });
 
     test('should initialize board with correct dimensions', () {
@@ -225,6 +226,22 @@ void main() {
 
       expect(gameLogic.currentPiece!.color, firstPiece.color);
       expect(gameLogic.heldPiece!.color, secondPiece.color);
+    });
+
+    test('should ignore holdPiece when enableHold is false', () {
+      gameLogic = GameLogic(enableHold: false);
+      gameLogic.startGame();
+
+      final originalPiece = gameLogic.currentPiece!;
+      final originalHeldPiece = gameLogic.heldPiece;
+      final originalCanHold = gameLogic.canHold;
+
+      gameLogic.holdPiece();
+
+      expect(gameLogic.enableHold, false);
+      expect(gameLogic.currentPiece!.color, originalPiece.color);
+      expect(gameLogic.heldPiece, originalHeldPiece);
+      expect(gameLogic.canHold, originalCanHold);
     });
 
     test('should calculate ghost piece position correctly', () {

--- a/test/multiplayer_game_config_test.dart
+++ b/test/multiplayer_game_config_test.dart
@@ -4,12 +4,16 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('MultiplayerGameConfig', () {
     test('encodes shared-pieces game starts with the seed', () {
-      const config = MultiplayerGameConfig.sharedPieces(pieceSeed: 123456);
+      const config = MultiplayerGameConfig.sharedPieces(
+        pieceSeed: 123456,
+        enableHold: false,
+      );
 
       expect(config.toGameStartMessage(), {
         'type': 'game_start',
         'mode': 'shared_pieces',
         'piece_seed': 123456,
+        'enable_hold': false,
       });
     });
 
@@ -37,6 +41,18 @@ void main() {
 
       expect(config.mode, MultiplayerGameMode.independent);
       expect(config.pieceSeed, isNull);
+      expect(config.enableHold, true);
+    });
+
+    test('decodes enable-hold from a game start payload', () {
+      final config = MultiplayerGameConfig.fromGameStartMessage({
+        'type': 'game_start',
+        'mode': 'independent',
+        'enable_hold': false,
+      });
+
+      expect(config.enableHold, false);
+      expect(config.mode, MultiplayerGameMode.independent);
     });
   });
 }

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -1,7 +1,7 @@
+import 'package:block_drop/settings/settings_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:block_drop/settings/settings_provider.dart';
 
 void main() {
   group('SettingsProvider', () {
@@ -17,6 +17,7 @@ void main() {
       expect(settings.musicEnabled, false);
       expect(settings.sfxEnabled, false);
       expect(settings.highScore, 0);
+      expect(settings.enableHold, true);
     });
 
     test('updateHighScore only updates when the new score is higher', () async {
@@ -105,6 +106,18 @@ void main() {
 
       await settings.setStyle(AppStyle.retro);
       expect(settings.style, AppStyle.retro);
+    });
+
+    test('setEnableHold updates the current hold preference', () async {
+      final settings = SettingsProvider();
+
+      expect(settings.enableHold, true);
+
+      await settings.setEnableHold(false);
+      expect(settings.enableHold, false);
+
+      await settings.setEnableHold(true);
+      expect(settings.enableHold, true);
     });
   });
 }


### PR DESCRIPTION
Hej,

this adds a setting to be able to disable the hold piece feature. For me it makes playing more enjoyable, because on the phone a miss-placed swipe to the left, to move a piece to the left, results in holding the piece. Also I am not really a fan of holding a piece.

In multiplayer mode the host can toggle the settings in the lobby. Per default it is still enabled.

cheers!
