### PR TITLE
chore: reuse cross-project Flutter fixes

### DIFF
--- a/.github/workflows/shared-quality.yml
+++ b/.github/workflows/shared-quality.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   quality:
-    uses: brandonp2412/Flexify/.github/workflows/flutter-quality.yml@2e2711a67022d0f69b63512a2320fc69a4ab4b1e
+    uses: brandonp2412/Flexify/.github/workflows/flutter-quality.yml@9cbb2208242a39aa4da3db833bac422891eeb5da

--- a/.github/workflows/shared-quality.yml
+++ b/.github/workflows/shared-quality.yml
@@ -1,0 +1,11 @@
+name: Shared Flutter quality
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  quality:
+    uses: brandonp2412/Flexify/.github/workflows/flutter-quality.yml@2e2711a67022d0f69b63512a2320fc69a4ab4b1e

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,13 @@
 - Before implementing features for a package, use the browser tool to read the latest README and API docs on `https://pub.dev/packages/[PACKAGE_NAME]`.
 - Note: Your Flutter MCP is for the SDK; use the browser for community packages like Drift, Riverpod, etc.
 
+# Cross-Project Flutter Reuse
+- Before implementing or fixing generic Flutter, Android, CI, navigation, theming, lifecycle, startup, logging, or performance behavior, search the sibling Flutter repositories (`Flexify`, `FitBook`, `MarketMonk`, `Quitter`, and `BlockDrop`) for an existing solution or regression test.
+- Prefer the shared workflows hosted by Flexify for app-agnostic CI behavior.
+- Reuse `frisbee_flutter_foundation` for generic runtime infrastructure when it improves this app, but retain stronger app-specific implementations such as Talker rather than replacing them merely for consistency.
+- When a generic fix is made here, check whether the same failure pattern exists in sibling apps before considering the task complete.
+- Keep shared-workflow and shared-package references pinned to a concrete commit.
+
 # Git & Version Control
 - **Completion Protocol**: When a task is successful, you MUST commit the work.
 - **Commit Format**: Use the [Conventional Commits](https://www.conventionalcommits.org/) standard (e.g., `feat:`, `fix:`, `chore:`).

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,15 +1,23 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'logging.dart';
 import 'screens/tetris_game_screen.dart';
 import 'settings/settings_provider.dart';
 
 Future<void> main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  installTalkerErrorHandlers();
-  talker.info('Starting Block Drop');
-  final settings = SettingsProvider();
-  await settings.load();
-  runApp(TetrisApp(settings: settings));
+  runZonedGuarded(
+    () async {
+      WidgetsFlutterBinding.ensureInitialized();
+      installTalkerErrorHandlers();
+      talker.info('Starting Block Drop');
+      final settings = SettingsProvider();
+      await settings.load();
+      runApp(TetrisApp(settings: settings));
+    },
+    (error, stackTrace) =>
+        talker.handle(error, stackTrace, 'Uncaught zone error'),
+  );
 }
 
 class TetrisApp extends StatefulWidget {


### PR DESCRIPTION
Superseded by #43. The cross-repository workflow approach was intentionally removed; BlockDrop now owns the CI and keeps its app-specific Talker implementation.